### PR TITLE
Correct examples in data model

### DIFF
--- a/deforestation_api/models/basin.py
+++ b/deforestation_api/models/basin.py
@@ -7,13 +7,13 @@ from deforestation_api.models.geometry import Polygon
 
 
 class LossYear(BaseModel):
-    year: int = Field(example=2022, description="Year when the loss was detected.")
+    year: int = Field(examples=[2022], description="Year when the loss was detected.")
     area: float = Field(
-        example=8.5095,
+        examples=[8.5095],
         description="Total tree cover loss within the basin polygon, in square kilometers.",
     )
     relative_area: float = Field(
-        example=0.0036,
+        examples=[0.0036],
         description=(
             "Tree cover loss within the basin polygon "
             "relative to the total area of the polygon."
@@ -23,26 +23,26 @@ class LossYear(BaseModel):
 
 class BasinProperties(BaseModel):
     downstream_id: int = Field(
-        example=1071114980,
+        examples=[1071114980],
         description=(
             "Id of the next downstream polygon for the current basin polygon. "
             "The value 0 means that there is no downstream connection."
         ),
     )
     basin_area: float = Field(
-        example=2350.0, description="Area of the basin polygon in square kilometers."
+        examples=[2350.0], description="Area of the basin polygon in square kilometers."
     )
     upstream_area: float = Field(
-        example=29444.1,
+        examples=[29444.1],
         description=(
             "Total upstream area in square kilometers, "
             "including the current polygon."
         ),
     )
-    start_year: int = Field(example=2020)
-    end_year: int = Field(example=2022)
+    start_year: int = Field(examples=[2020])
+    end_year: int = Field(examples=[2022])
     daterange_tot_treeloss: float = Field(
-        example=35.7217,
+        examples=[35.7217],
         description=(
             "Total tree cover loss, in square kilometers, "
             "within the basin polygon over the time period "
@@ -50,7 +50,7 @@ class BasinProperties(BaseModel):
         ),
     )
     daterange_rel_treeloss: float = Field(
-        example=0.0152,
+        examples=[0.0152],
         description=(
             "Tree cover loss within the basin polygon "
             "relative to the total area of the polygon, "
@@ -62,7 +62,9 @@ class BasinProperties(BaseModel):
 
 
 class DeforestationBasinFeature(BaseModel):
-    id: int = Field(example=1071119930, description="Unique basin polygon identifier.")
+    id: int = Field(
+        examples=[1071119930], description="Unique basin polygon identifier."
+    )
     type: Literal["Feature"]
     properties: BasinProperties
     geometry: Polygon

--- a/deforestation_api/models/geometry.py
+++ b/deforestation_api/models/geometry.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import Annotated, Literal
 from pydantic import BaseModel, Field
 
 Longitude = Annotated[float, Field(ge=-180, le=180)]
 Latitude = Annotated[float, Field(ge=-90, le=90)]
 Position = tuple[Longitude, Latitude]
-LinearRing = Annotated[list[Position], Field(min_length=4)]
+LinearRing = Annotated[
+    list[Position],
+    Field(
+        examples=[
+            [[-20.0, -10.0], [50.0, -10.0], [50.0, 10.0], [-20.0, 10.0], [-20.0, -10.0]]
+        ],
+        min_length=4,
+    ),
+]
 PolygonCoords = list[LinearRing]
 
 


### PR DESCRIPTION
I noticed the coordinates in the example response in the documentation were `null`. Added an example polygon. Also changed the `example` arguments in `Field` to `examples` since it generated a deprecation warning.