### PR TITLE
fix: Missing logo

### DIFF
--- a/deployment/kubernetes/deforestation-api.yaml
+++ b/deployment/kubernetes/deforestation-api.yaml
@@ -14,7 +14,7 @@ spec:
         app: deforestation-api
     spec:
       containers:
-        - image: ghcr.io/openearthplatforminitiative/deforestation-api:0.2.1
+        - image: ghcr.io/openearthplatforminitiative/deforestation-api:0.2.2
           name: deforestation-api
           ports:
             - containerPort: 8080
@@ -22,7 +22,12 @@ spec:
             - name: API_ROOT_PATH
               value: "/deforestation"
             - name: VERSION
-              value: 0.2.1
+              value: 0.2.2
+            - name: API_DOMAIN
+              valueFrom:
+                configMapKeyRef:
+                  name: openepi-apps-config
+                  key: api_domain
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The logo is missing in the docs in the latest deployment of the deforestation API. I think this is because the `API_DOMAIN` environment variable was missing, and therefore didn't override the default value of `settings.api_domain`, i.e. localhost.